### PR TITLE
Fix monitor trade logging

### DIFF
--- a/telegram_bot/bot.py
+++ b/telegram_bot/bot.py
@@ -392,7 +392,12 @@ async def monitor_trade_callback(context: CallbackContext):
         exit_price = tp
         commission = (entry_price + exit_price) * position_size * COMMISSION_RATE
         profit = (exit_price - entry_price) * position_size - commission
-        log_trade(...)
+        log_trade(
+            entry_price=entry_price,
+            exit_price=exit_price,
+            position_size=position_size,
+            profit=profit
+        )
         close_position()
         context.job.schedule_removal()
 


### PR DESCRIPTION
## Summary
- properly pass trade parameters to `log_trade` when take-profit is hit

## Testing
- `python -m py_compile telegram_bot/bot.py positions_db.py trading/executor.py trading/risk_manager.py backtesting/backtesting.py data/data_manager.py indicators/indicators.py models/preprocess.py models/lstm_model.py utils/config.py utils/logging_config.py trading/__init__.py execution/__init__.py backtesting/__init__.py telegram_bot/__init__.py 324234/__init__.py`


------
https://chatgpt.com/codex/tasks/task_e_684435a57d1c832b82e6c5d920f839e0