### PR TITLE
Fix docstring in RSI indicator

### DIFF
--- a/indicators/indicators.py
+++ b/indicators/indicators.py
@@ -7,7 +7,7 @@ logger = logging.getLogger(__name__)
 
 def calculate_rsi(df, period=14):
     """
-    Расчитывает Relative Strength Index (RSI) для DataFrame.
+    Рассчитывает Relative Strength Index (RSI) для DataFrame.
     """
     delta = df['close'].diff()
     gain = delta.where(delta > 0, 0)


### PR DESCRIPTION
## Summary
- fix typo in calculate_rsi docstring

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68443cc18704832bb6d46e25fa453742