### PR TITLE
Remove stray comment from telegram bot

### DIFF
--- a/telegram_bot/bot.py
+++ b/telegram_bot/bot.py
@@ -207,7 +207,7 @@ async def monitor_callback(context: CallbackContext):
             f"📈 Вероятность: {prob:.2f}%\n"
             f"🔔 {signal.replace('_', ' ')}\n"
             f"• Risk: {risk_pct * 100:.2f}%\n"
-            f"• Объём: {position_size:.6f} BTC\n"  # ← вот она
+            f"• Объём: {position_size:.6f} BTC\n"
             f"• Entry: {entry_price:.2f}\n"
             f"• SL: {stop_price:.2f}\n"
             f"• TP: {take_price:.2f}"


### PR DESCRIPTION
## Summary
- clean up stray `# ← вот она` comment in bot monitoring

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68443e09c954832b9859fe864496cdc6