### PR TITLE
Fix duplicate commission_rate variable

### DIFF
--- a/utils/config.py
+++ b/utils/config.py
@@ -15,4 +15,3 @@ COMMISSION_RATE = float(os.getenv("COMMISSION_RATE", "0.001"))
 DEFAULT_RISK_PCT = 1.0    # риск 1% от баланса
 DEFAULT_SL_PCT   = 2.0    # стоп-лосс 2% от цены входа
 DEFAULT_TP_RATIO = 2.0    # тейк-профит в 2 раза дальше SL
-COMMISSION_RATE = float(os.getenv("COMMISSION_RATE", "0.001"))


### PR DESCRIPTION
## Summary
- remove extra `COMMISSION_RATE` line in `utils/config.py`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6844499576f0832bab1bc70207a5eb0e