### PR TITLE
Fix risk percent in chart command

### DIFF
--- a/telegram_bot/bot.py
+++ b/telegram_bot/bot.py
@@ -269,7 +269,8 @@ async def chart_command(update: Update, context: CallbackContext):
                 balance=usd_balance,
                 entry_price=entry_price,
                 stop_loss_pct=DEFAULT_SL_PCT,
-                risk_pct=risk_per_trade
+                # calculate_position_size expects percent, risk_per_trade is a fraction
+                risk_pct=risk_per_trade * 100
             )
             stop_price, take_price = calculate_sl_tp_levels(
                 entry_price, DEFAULT_SL_PCT, DEFAULT_TP_RATIO


### PR DESCRIPTION
## Summary
- pass the risk percentage in percent for `chart` command
- clarify that `risk_per_trade` is stored as a fraction

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684453ef3eb0832b96f68f84b79e5d60