### PR TITLE
Fix risk_pct usage

### DIFF
--- a/telegram_bot/bot.py
+++ b/telegram_bot/bot.py
@@ -171,7 +171,7 @@ async def monitor_callback(context: CallbackContext):
             balance=usd_balance,
             entry_price=entry_price,
             stop_loss_pct=DEFAULT_SL_PCT,
-            risk_pct=risk_pct
+            risk_pct=risk_pct * 100
         )
         stop_price, take_price = calculate_sl_tp_levels(
             entry_price=entry_price,

--- a/trading/risk_manager.py
+++ b/trading/risk_manager.py
@@ -5,7 +5,7 @@ def calculate_position_size(balance, entry_price, stop_loss_pct, risk_pct):
     balance: текущий баланс в USDT
     entry_price: цена входа
     stop_loss_pct: допустимый SL в процентах от entry_price
-    risk_pct: процент риска от баланса (1–2%)
+    risk_pct: процент риска от баланса (например 1 для 1%)
     """
     dollar_risk = balance * (risk_pct / 100)
     distance_to_sl = entry_price * (stop_loss_pct / 100)


### PR DESCRIPTION
## Summary
- adjust risk_pct handling when monitoring signal
- clarify risk_pct docs for calculate_position_size

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684454d55054832bbef4d46e815ca109