### PR TITLE
Improve backtesting accuracy

### DIFF
--- a/backtesting/backtesting.py
+++ b/backtesting/backtesting.py
@@ -1,10 +1,8 @@
-import pandas as pd
 import logging
 from trading.risk_manager import calculate_position_size, calculate_sl_tp_levels
 from utils.config import DEFAULT_RISK_PCT, DEFAULT_SL_PCT, DEFAULT_TP_RATIO
 
-# включаем вывод INFO-сообщений
-logging.basicConfig(level=logging.INFO, format="%(message)s")
+# включаем вывод INFO-сообщений при запуске скрипта
 logger = logging.getLogger(__name__)
 
 class Backtester:
@@ -52,18 +50,21 @@ class Backtester:
                 )
                 # Стоп‑лосс
                 if row["low"] <= stop_price:
+                    self.balance += entry_price * position_size
                     self.simulate_trade(entry_price, stop_price, position_size, exit_type="SL")
                     in_position = False
                     logger.info(f"SL hit at {stop_price:.2f}")
                     continue
                 # Тейк‑профит
                 if row["high"] >= take_price:
+                    self.balance += entry_price * position_size
                     self.simulate_trade(entry_price, take_price, position_size, exit_type="TP")
                     in_position = False
                     logger.info(f"TP hit at {take_price:.2f}")
                     continue
                 # Закрытие по сигналу SELL
                 if sig == "SELL":
+                    self.balance += entry_price * position_size
                     self.simulate_trade(entry_price, price, position_size, exit_type="SELL")
                     in_position = False
                     logger.info(f"Close by SELL at {price:.2f}")
@@ -84,16 +85,23 @@ class Backtester:
                     tp_ratio=DEFAULT_TP_RATIO
                 )
                 in_position = True
+                self.balance -= entry_price * position_size
                 logger.info(
                     f"OPEN ▶ price={entry_price:.2f}, size={position_size:.6f}, "
                     f"SL={stop_price:.2f}, TP={take_price:.2f}"
                 )
+
+        if in_position:
+            self.balance += entry_price * position_size
+            last_close = df['close'].iloc[-1]
+            self.simulate_trade(entry_price, last_close, position_size, exit_type="EOD")
 
         logger.info(f"Бэктест завершен. Итоговый баланс: {self.balance:.2f}")
         return self.trades
 
 
 if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO, format="%(message)s")
     from data.data_manager import get_candlestick_data
     from indicators.indicators import calculate_indicators
     from collections import Counter

--- a/data/data_manager.py
+++ b/data/data_manager.py
@@ -6,7 +6,6 @@ from datetime import datetime
 import os
 import logging
 from dotenv import load_dotenv
-from utils.config import MARGIN_MODE, LEVERAGE
 from utils.config import BYBIT_API_KEY, BYBIT_API_SECRET
 
 
@@ -27,19 +26,29 @@ def init_exchange():
     return exchange
 
 
-def get_candlestick_data(symbol="BTC/USDT", timeframe="1h", since=None):
-    """
-    Получает данные OHLCV и возвращает их в виде DataFrame.
-    """
+def get_candlestick_data(symbol="BTC/USDT", timeframe="1h", since=None, limit=None):
+    """Получает данные OHLCV и возвращает их в виде DataFrame."""
     exchange = init_exchange()
+    all_rows = []
+    fetch_since = since
     try:
-        logger.info(f"Запрашиваю OHLCV для {symbol} ({timeframe}), since={since}")
-        ohlcv = exchange.fetch_ohlcv(symbol, timeframe, since=since, limit=500)
-        df = pd.DataFrame(ohlcv, columns=['timestamp', 'open', 'high', 'low', 'close', 'volume'])
+        while True:
+            logger.info(f"Запрашиваю OHLCV для {symbol} ({timeframe}), since={fetch_since}")
+            batch = exchange.fetch_ohlcv(symbol, timeframe, since=fetch_since, limit=500)
+            if not batch:
+                break
+            all_rows.extend(batch)
+            if limit and len(all_rows) >= limit:
+                all_rows = all_rows[:limit]
+                break
+            if len(batch) < 500:
+                break
+            fetch_since = batch[-1][0] + 1
+        df = pd.DataFrame(all_rows, columns=['timestamp', 'open', 'high', 'low', 'close', 'volume'])
         df['start_at'] = pd.to_datetime(df['timestamp'], unit='ms')
         logger.info(f"Получено {len(df)} строк данных для {symbol}.")
         return df
-    except Exception as e:
+    except Exception:
         logger.exception(f"Ошибка при получении OHLCV для {symbol}:")
         return pd.DataFrame()
 

--- a/tests/test_backtester.py
+++ b/tests/test_backtester.py
@@ -1,0 +1,43 @@
+import pytest
+import pandas as pd
+from backtesting.backtesting import Backtester
+
+
+def test_basic_buy_sell_no_commission():
+    df = pd.DataFrame([
+        {"open": 100, "high": 101, "low": 99, "close": 100, "signal": "BUY"},
+        {"open": 101, "high": 102, "low": 100, "close": 101, "signal": "HOLD"},
+        {"open": 102, "high": 103, "low": 99, "close": 101, "signal": "SELL"},
+    ])
+    bt = Backtester(initial_balance=10000, commission_rate=0)
+    trades = bt.run_backtest(df)
+    assert len(trades) == 1
+    assert trades[0]["exit_type"] == "SELL"
+    assert bt.balance == pytest.approx(10050)
+
+
+def test_close_on_end_of_data():
+    df = pd.DataFrame([
+        {"open": 100, "high": 101, "low": 99, "close": 100, "signal": "BUY"},
+        {"open": 101, "high": 102, "low": 100, "close": 100, "signal": "HOLD"},
+    ])
+    bt = Backtester(initial_balance=10000, commission_rate=0)
+    trades = bt.run_backtest(df)
+    assert len(trades) == 1
+    assert trades[0]["exit_type"] == "EOD"
+    assert bt.balance == pytest.approx(10000)
+
+
+def test_commission_applied():
+    df = pd.DataFrame([
+        {"open": 100, "high": 101, "low": 99, "close": 100, "signal": "BUY"},
+        {"open": 101, "high": 102, "low": 100, "close": 102, "signal": "SELL"},
+    ])
+    bt = Backtester(initial_balance=10000, commission_rate=0.001)
+    trades = bt.run_backtest(df)
+    assert len(trades) == 1
+    profit = trades[0]["profit"]
+    expected_commission = (100 * 50 + 102 * 50) * 0.001
+    expected_profit = (102 - 100) * 50 - expected_commission
+    assert profit == pytest.approx(expected_profit)
+    assert bt.balance == pytest.approx(10000 + expected_profit)


### PR DESCRIPTION
## Summary
- drop unused pandas import and move logging setup under main
- settle open positions at the end of the backtest
- deduct entry cost when trades open
- extend OHLCV downloader to fetch multiple batches
- add regression tests for `Backtester`

## Testing
- `pip install flake8` *(fails: cannot connect to proxy)*
- `pip install pandas` *(fails: cannot connect to proxy)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_68445932fd0c832b8327f492b57d35b2