### PR TITLE
Fix /monitor chat context

### DIFF
--- a/telegram_bot/bot.py
+++ b/telegram_bot/bot.py
@@ -83,7 +83,8 @@ async def start_monitor(update: Update, context: CallbackContext):
         interval=15 * 60,      # 15 минут
         first=0,               # запуск сразу
         name=str(chat_id),     # имя Job = чат id
-        data=chat_id        # передаём chat_id в колбэк
+        data=chat_id,          # передаём chat_id в колбэк
+        chat_id=chat_id        # нужно для context.chat_data
     )
     await update.message.reply_text("Мониторинг запущен: буду присылать сигналы каждые 15 мин.")
 


### PR DESCRIPTION
## Summary
- ensure `chat_id` is passed to job queue for `/monitor`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6846f00bf3f0832bb14d1fe5d05f3714