### PR TITLE
Add optional private mode for candlestick data

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,3 +34,15 @@ The application expects the following variables in the `.env` file:
 | `BYBIT_MARGIN_MODE` | Margin mode for orders (`cross` or `isolated`). |
 | `BYBIT_LEVERAGE` | Leverage value to use when placing orders. |
 
+## Bybit API Client
+
+The module `utils.bybit_client` exposes two helper functions:
+
+* `get_public_client()` – returns a CCXT client for public endpoints.
+* `get_private_client()` – returns an authenticated client using the keys from
+  the `.env` file.
+
+Functions like `get_candlestick_data()` accept a `private` argument. Set it to
+`True` when you need to access data that requires authentication. The default is
+`False` which performs requests using the public client.
+

--- a/backtesting/backtesting.py
+++ b/backtesting/backtesting.py
@@ -108,7 +108,7 @@ if __name__ == "__main__":
     import matplotlib.pyplot as plt
 
     # 1) Загружаем данные
-    df = get_candlestick_data(symbol="BTC/USDT", timeframe="1h")
+    df = get_candlestick_data(symbol="BTC/USDT", timeframe="1h", private=True)
     if df.empty:
         print("Не удалось получить данные для бэктеста")
         exit(1)

--- a/data/data_manager.py
+++ b/data/data_manager.py
@@ -6,29 +6,39 @@ from datetime import datetime
 import os
 import logging
 from dotenv import load_dotenv
-from utils.config import BYBIT_API_KEY, BYBIT_API_SECRET
+from utils.bybit_client import get_public_client, get_private_client
 
 
 
 load_dotenv()
 logger = logging.getLogger(__name__)
 
-def init_exchange():
+def init_exchange(private: bool = False):
+    """Return a CCXT Bybit client.
+
+    Parameters
+    ----------
+    private : bool, optional
+        If ``True`` an authenticated client is created using API keys.
+        Otherwise a public client is returned. Defaults to ``False``.
     """
-    Публичный клиент CCXT для fetch_ohlcv,
-    без автоматического вызова fetch_currencies().
-    """
-    exchange = ccxt.bybit({
-        'enableRateLimit': True,
-    })
-    # Отключаем fetch_currencies, чтобы не вызывалось privateGetV5AssetCoinQueryInfo
-    exchange.options['fetchCurrencies'] = False
+
+    if private:
+        exchange = get_private_client()
+    else:
+        exchange = get_public_client()
     return exchange
 
 
-def get_candlestick_data(symbol="BTC/USDT", timeframe="1h", since=None, limit=None):
+def get_candlestick_data(
+    symbol: str = "BTC/USDT",
+    timeframe: str = "1h",
+    since: int | None = None,
+    limit: int | None = None,
+    private: bool = False,
+):
     """Получает данные OHLCV и возвращает их в виде DataFrame."""
-    exchange = init_exchange()
+    exchange = init_exchange(private=private)
     all_rows = []
     fetch_since = since
     try:

--- a/telegram_bot/bot.py
+++ b/telegram_bot/bot.py
@@ -6,7 +6,7 @@ import numpy as np
 from datetime import time
 from telegram import Update
 from telegram.ext import Application, CommandHandler, CallbackContext
-from utils.config import TOKEN, BYBIT_API_KEY, BYBIT_API_SECRET
+from utils.config import TOKEN
 from utils.config import DEFAULT_TP_RATIO, DEFAULT_SL_PCT, DEFAULT_RISK_PCT, COMMISSION_RATE
 from data.data_manager import get_candlestick_data
 from indicators.indicators import calculate_indicators
@@ -40,7 +40,7 @@ async def status_command(update: Update, context: CallbackContext):
         await update.message.reply_text("Получаю текущее состояние стратегии...")
 
         # Получаем исторические данные (например, последние 300 свечей)
-        df = get_candlestick_data(symbol="BTC/USDT", timeframe="1h")
+        df = get_candlestick_data(symbol="BTC/USDT", timeframe="1h", private=True)
         if df.empty:
             await update.message.reply_text("Не удалось получить данные для отображения состояния.")
             return
@@ -108,7 +108,7 @@ async def monitor_callback(context: CallbackContext):
         usd_balance = state["usd_balance"]
 
         # ─── 2) Получаем и подготавливаем данные ──────────────────────
-        df = get_candlestick_data(symbol="BTC/USDT", timeframe="1h")
+        df = get_candlestick_data(symbol="BTC/USDT", timeframe="1h", private=True)
         if df.empty:
             await context.bot.send_message(
                 chat_id,
@@ -189,7 +189,7 @@ async def monitor_callback(context: CallbackContext):
             # закрываем все текущие позиции
             positions = get_open_positions()
             for pos in positions:
-                df_latest = get_candlestick_data(pos["symbol"], "1m")
+                df_latest = get_candlestick_data(pos["symbol"], "1m", private=True)
                 current_price = df_latest["close"].iloc[-1]
                 resp = execute_exit(pos["symbol"], pos["id"], current_price)
             await context.bot.send_message(chat_id, f"🔔 Авто-закрытие позиций выполнено.")
@@ -232,7 +232,7 @@ async def chart_command(update: Update, context: CallbackContext):
 
         # 2) данные и индикаторы
 
-        df = get_candlestick_data("BTC/USDT", "1h")
+        df = get_candlestick_data("BTC/USDT", "1h", private=True)
         logger.info(f"[CHART] Получено строк: {len(df)}")
         if df.empty:
             return await update.message.reply_text("Нет данных для прогноза.")
@@ -360,7 +360,7 @@ async def monitor_trade_callback(context: CallbackContext):
     if not state.get("in_trade", False):
         return  # вы уже закрыли
 
-    price = get_candlestick_data("BTC/USDT","1m")["close"].iloc[-1]
+    price = get_candlestick_data("BTC/USDT", "1m", private=True)["close"].iloc[-1]
     sl = state["stop_loss"]
     tp = state["take_profit"]
 
@@ -410,7 +410,7 @@ async def auto_buy_cmd(update: Update, context: CallbackContext):
     symbol = "BTC/USDT"
 
     # 1) Получаем последнюю минутную цену
-    df = get_candlestick_data(symbol, "1m")
+    df = get_candlestick_data(symbol, "1m", private=True)
     if df.empty:
         return await update.message.reply_text("⚠️ Нет данных для открытия позиции.")
     price = df["close"].iloc[-1]
@@ -462,7 +462,7 @@ async def auto_sell_cmd(update: Update, context: CallbackContext):
     messages = []
     for pos in positions:
         # берём текущую цену
-        df = get_candlestick_data(pos["symbol"], "1m")
+        df = get_candlestick_data(pos["symbol"], "1m", private=True)
         price = df["close"].iloc[-1]
         resp = execute_exit(pos["symbol"], pos["id"], price)
         messages.append(f"🔴 Closed #{pos['id']}: exit={price:.2f}")
@@ -479,7 +479,7 @@ async def train_command(update: Update, context: CallbackContext):
         await update.message.reply_text("Начинаем обучение модели...")
 
         # 1. Получаем данные с биржи (или из базы)
-        df = get_candlestick_data(symbol="BTC/USDT", timeframe="1h")
+        df = get_candlestick_data(symbol="BTC/USDT", timeframe="1h", private=True)
         logger.info(f"[TRAIN] Получено строк: {len(df)}")
         if df.empty:
             await update.message.reply_text("Не удалось получить данные. Попробуйте позже.")
@@ -519,7 +519,7 @@ async def train_command(update: Update, context: CallbackContext):
 async def retrain_callback(context: CallbackContext):
     logger.info("=== Начинаю автоматическое переобучение ===")
     # 1) Получаем и готовим данные
-    df = get_candlestick_data(symbol="BTC/USDT", timeframe="1h")
+    df = get_candlestick_data(symbol="BTC/USDT", timeframe="1h", private=True)
     logger.info(f"[TRAIN] Получено строк: {len(df)}")
     if df.empty:
         logger.error("Retrain: не удалось скачать данные")
@@ -548,7 +548,7 @@ async def backtest_command(update: Update, context: CallbackContext):
         await update.message.reply_text("Запуск бэктеста стратегии...")
 
         # Получаем исторические данные (например, последние 300 свечей)
-        df = get_candlestick_data(symbol="BTC/USDT", timeframe="1h")
+        df = get_candlestick_data(symbol="BTC/USDT", timeframe="1h", private=True)
         if df.empty:
             await update.message.reply_text("Не удалось получить исторические данные.")
             return
@@ -598,7 +598,7 @@ async def backtest_report(update: Update, context: CallbackContext):
     await update.message.reply_text("Запускаю полный отчёт по бэктесту…")
 
     # 1) Получаем данные и сигналы
-    df = get_candlestick_data("BTC/USDT", "1h")
+    df = get_candlestick_data("BTC/USDT", "1h", private=True)
     df = calculate_indicators(df)
     df["signal"] = df["RSI"].apply(lambda rsi: "BUY" if rsi < 30 else ("SELL" if rsi > 70 else "HOLD"))
 

--- a/utils/bybit_client.py
+++ b/utils/bybit_client.py
@@ -1,0 +1,24 @@
+import ccxt
+from .config import BYBIT_API_KEY, BYBIT_API_SECRET
+
+
+def get_public_client():
+    """Return a CCXT Bybit client for public endpoints."""
+    exchange = ccxt.bybit({
+        'enableRateLimit': True,
+    })
+    # Avoid unnecessary private calls
+    exchange.options['fetchCurrencies'] = False
+    return exchange
+
+
+def get_private_client():
+    """Return an authenticated CCXT Bybit client."""
+    exchange = ccxt.bybit({
+        'apiKey': BYBIT_API_KEY,
+        'secret': BYBIT_API_SECRET,
+        'enableRateLimit': True,
+        'options': {'defaultType': 'future'},
+    })
+    exchange.options['fetchCurrencies'] = False
+    return exchange


### PR DESCRIPTION
## Summary
- add `utils.bybit_client` with helper constructors
- allow `data_manager` to return a private or public client
- request private data in Telegram bot and backtesting script
- document the new mode in README

## Testing
- `pip install pandas numpy matplotlib --quiet`
- `pip install python-dotenv --quiet`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6847074c5e80832b8db002bc1a68d044