### PR TITLE
Add strategy evaluator and extra indicators

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,13 @@ This project contains a cryptocurrency trading bot with a Telegram interface. It
 
 The backtesting engine can be executed directly using `python backtesting/backtesting.py`.
 
+To compare several example strategies run:
+
+```bash
+python backtesting/strategy_evaluator.py
+```
+This script calculates indicators, applies a few built‑in strategies and prints the final balance for each.
+
 ## Environment Variables
 
 The application expects the following variables in the `.env` file:

--- a/backtesting/strategies.py
+++ b/backtesting/strategies.py
@@ -1,0 +1,32 @@
+import pandas as pd
+
+
+def rsi_strategy(df: pd.DataFrame) -> pd.DataFrame:
+    """Generate BUY/SELL/HOLD signals based on RSI."""
+    df["signal"] = df["RSI"].apply(
+        lambda rsi: "BUY" if rsi < 30 else ("SELL" if rsi > 70 else "HOLD")
+    )
+    return df
+
+
+def macd_rsi_strategy(df: pd.DataFrame) -> pd.DataFrame:
+    """Combine MACD crossovers with RSI filters."""
+    df["signal"] = "HOLD"
+    df.loc[(df["MACD"] > df["MACD_signal"]) & (df["RSI"] < 30), "signal"] = "BUY"
+    df.loc[(df["MACD"] < df["MACD_signal"]) & (df["RSI"] > 70), "signal"] = "SELL"
+    return df
+
+
+def bollinger_strategy(df: pd.DataFrame) -> pd.DataFrame:
+    """Buy when price is below the lower band, sell above the upper band."""
+    df["signal"] = "HOLD"
+    df.loc[df["close"] < df["BB_lower"], "signal"] = "BUY"
+    df.loc[df["close"] > df["BB_upper"], "signal"] = "SELL"
+    return df
+
+
+STRATEGIES = {
+    "RSI only": rsi_strategy,
+    "MACD + RSI": macd_rsi_strategy,
+    "Bollinger": bollinger_strategy,
+}

--- a/backtesting/strategy_evaluator.py
+++ b/backtesting/strategy_evaluator.py
@@ -1,0 +1,35 @@
+import logging
+from data.data_manager import get_candlestick_data
+from indicators.indicators import calculate_indicators
+from backtesting.backtesting import Backtester
+from backtesting.strategies import STRATEGIES
+
+logger = logging.getLogger(__name__)
+
+
+def evaluate(symbol: str = "BTC/USDT", timeframe: str = "1h", limit: int = 500):
+    df = get_candlestick_data(symbol=symbol, timeframe=timeframe, limit=limit, private=False)
+    if df.empty:
+        logger.error("Нет данных для оценки")
+        return
+
+    df = calculate_indicators(df)
+
+    results = []
+    for name, strategy in STRATEGIES.items():
+        df_copy = strategy(df.copy())
+        bt = Backtester(initial_balance=10000)
+        bt.run_backtest(df_copy, signal_column="signal")
+        results.append((name, bt.balance))
+
+    results.sort(key=lambda x: x[1], reverse=True)
+    print("=== Strategy results ===")
+    for name, bal in results:
+        print(f"{name:12s} -> final balance: {bal:.2f}")
+    if results:
+        print(f"Best strategy: {results[0][0]}")
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO, format="%(message)s")
+    evaluate()

--- a/indicators/indicators.py
+++ b/indicators/indicators.py
@@ -42,6 +42,37 @@ def calculate_atr(df, period=14):
     logger.info("ATR рассчитан.")
     return df
 
+def calculate_sma(df, period=20):
+    """Adds Simple Moving Average (SMA)."""
+    df[f'SMA_{period}'] = df['close'].rolling(window=period).mean()
+    logger.info("SMA рассчитана.")
+    return df
+
+def calculate_ema(df, period=20):
+    """Adds Exponential Moving Average (EMA)."""
+    df[f'EMA_{period}'] = df['close'].ewm(span=period, adjust=False).mean()
+    logger.info("EMA рассчитана.")
+    return df
+
+def calculate_bollinger_bands(df, period=20, std_factor=2):
+    """Adds Bollinger Bands (upper, middle, lower)."""
+    sma = df['close'].rolling(window=period).mean()
+    std = df['close'].rolling(window=period).std()
+    df['BB_middle'] = sma
+    df['BB_upper'] = sma + std_factor * std
+    df['BB_lower'] = sma - std_factor * std
+    logger.info("Bollinger Bands рассчитаны.")
+    return df
+
+def calculate_stochastic(df, k_period=14, d_period=3):
+    """Adds Stochastic Oscillator %K and %D."""
+    low_min = df['low'].rolling(window=k_period).min()
+    high_max = df['high'].rolling(window=k_period).max()
+    df['STOCH_K'] = 100 * (df['close'] - low_min) / (high_max - low_min)
+    df['STOCH_D'] = df['STOCH_K'].rolling(window=d_period).mean()
+    logger.info("Stochastic рассчитан.")
+    return df
+
 def calculate_indicators(df):
     """
     Запускает расчёт всех индикаторов и удаляет строки с NaN.
@@ -49,6 +80,10 @@ def calculate_indicators(df):
     df = calculate_rsi(df)
     df = calculate_macd(df)
     df = calculate_atr(df)
+    df = calculate_sma(df)
+    df = calculate_ema(df)
+    df = calculate_bollinger_bands(df)
+    df = calculate_stochastic(df)
     df.dropna(inplace=True)
     logger.info("Все индикаторы рассчитаны и начальные NaN значения удалены.")
     return df

--- a/tests/test_indicators.py
+++ b/tests/test_indicators.py
@@ -1,0 +1,20 @@
+import pandas as pd
+import numpy as np
+from indicators.indicators import calculate_indicators
+
+
+def test_calculate_indicators_adds_columns():
+    data = {
+        'open':  np.arange(1, 31),
+        'high':  np.arange(2, 32),
+        'low':   np.arange(0, 30),
+        'close': np.arange(1, 31)
+    }
+    df = pd.DataFrame(data)
+    result = calculate_indicators(df)
+    expected_cols = [
+        'RSI', 'MACD', 'MACD_signal', 'ATR', 'SMA_20', 'EMA_20',
+        'BB_upper', 'BB_middle', 'BB_lower', 'STOCH_K', 'STOCH_D'
+    ]
+    for col in expected_cols:
+        assert col in result.columns


### PR DESCRIPTION
## Summary
- implement SMA, EMA, Bollinger Bands and Stochastic indicators
- add several simple strategies and evaluation script
- document strategy evaluator usage in README
- test presence of new indicator columns

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68483095da04832b96be2fc8f251fe57