### PR TITLE
Fix syntax errors in strategies and cleanup README

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,12 +26,6 @@ To compare several example strategies run:
 ```bash
 python backtesting/strategy_evaluator.py
 ```
- p02xe1-codex/проанализировать-индикаторы-для-крипто-бота
-This script calculates indicators, runs about twenty built-in strategy variations
-and prints the final balance for each.
-
-This script calculates indicators, applies a few built‑in strategies and prints the final balance for each.
- main
 
 ## Environment Variables
 

--- a/backtesting/strategies.py
+++ b/backtesting/strategies.py
@@ -25,7 +25,6 @@ def bollinger_strategy(df: pd.DataFrame) -> pd.DataFrame:
     return df
 
 
- p02xe1-codex/проанализировать-индикаторы-для-крипто-бота
 def macd_strategy(df: pd.DataFrame) -> pd.DataFrame:
     """Signals based solely on MACD crossovers."""
     df["signal"] = "HOLD"
@@ -252,9 +251,4 @@ STRATEGIES = {
     "RSI + EMA": rsi_ema_strategy,
     "SMA + MACD": sma_macd_strategy,
 
-STRATEGIES = {
-    "RSI only": rsi_strategy,
-    "MACD + RSI": macd_rsi_strategy,
-    "Bollinger": bollinger_strategy,
- main
 }


### PR DESCRIPTION
## Summary
- repair corrupted `backtesting/strategies.py`
- clean extraneous text from README

## Testing
- `python -m py_compile backtesting/strategies.py`
- `find . -name '*.py' -print0 | xargs -0 python -m py_compile`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68484921202c832b928eab4ca51c5a58