### PR TITLE
Add indicator combination strategies

### DIFF
--- a/backtesting/strategies.py
+++ b/backtesting/strategies.py
@@ -252,3 +252,68 @@ STRATEGIES = {
     "SMA + MACD": sma_macd_strategy,
 
 }
+
+# --- Programmatically generated strategies ---------------------------------
+
+from itertools import combinations
+
+COMBO_INDICATORS = [
+    "RSI",
+    "MACD",
+    "ATR",
+    "SMA",
+    "EMA",
+    "Bollinger",
+    "Stochastic",
+]
+
+
+def _create_combo_strategy(indicators: tuple[str, ...]):
+    """Return a strategy that requires all *indicators* to agree."""
+
+    def strategy(df: pd.DataFrame) -> pd.DataFrame:
+        df["signal"] = "HOLD"
+        buy = pd.Series(True, index=df.index)
+        sell = pd.Series(True, index=df.index)
+
+        for ind in indicators:
+            if ind == "RSI":
+                buy &= df["RSI"] < 30
+                sell &= df["RSI"] > 70
+            elif ind == "MACD":
+                buy &= df["MACD"] > df["MACD_signal"]
+                sell &= df["MACD"] < df["MACD_signal"]
+            elif ind == "ATR":
+                buy &= df["ATR"] > df["ATR"].shift()
+                sell &= df["ATR"] < df["ATR"].shift()
+            elif ind == "SMA":
+                buy &= df["close"] > df["SMA_20"]
+                sell &= df["close"] < df["SMA_20"]
+            elif ind == "EMA":
+                buy &= df["close"] > df["EMA_20"]
+                sell &= df["close"] < df["EMA_20"]
+            elif ind == "Bollinger":
+                buy &= df["close"] < df["BB_lower"]
+                sell &= df["close"] > df["BB_upper"]
+            elif ind == "Stochastic":
+                buy &= df["STOCH_K"] > df["STOCH_D"]
+                sell &= df["STOCH_K"] < df["STOCH_D"]
+
+        df.loc[buy, "signal"] = "BUY"
+        df.loc[sell, "signal"] = "SELL"
+        return df
+
+    return strategy
+
+
+def generate_all_indicator_strategies() -> dict[str, callable]:
+    """Return strategy functions for every non-empty indicator combination."""
+    strategies = {}
+    for r in range(1, len(COMBO_INDICATORS) + 1):
+        for combo in combinations(COMBO_INDICATORS, r):
+            name = " + ".join(combo)
+            strategies[name] = _create_combo_strategy(combo)
+    return strategies
+
+
+STRATEGIES.update(generate_all_indicator_strategies())

--- a/backtesting/strategy_evaluator.py
+++ b/backtesting/strategy_evaluator.py
@@ -2,12 +2,17 @@ import logging
 from data.data_manager import get_candlestick_data
 from indicators.indicators import calculate_indicators
 from backtesting.backtesting import Backtester
-from backtesting.strategies import STRATEGIES
+from backtesting.strategies import STRATEGIES, generate_all_indicator_strategies
 
 logger = logging.getLogger(__name__)
 
 
-def evaluate(symbol: str = "BTC/USDT", timeframe: str = "1h", limit: int = 500):
+def evaluate(
+    symbol: str = "BTC/USDT",
+    timeframe: str = "1h",
+    limit: int = 500,
+    include_combos: bool = False,
+):
     df = get_candlestick_data(symbol=symbol, timeframe=timeframe, limit=limit, private=False)
     if df.empty:
         logger.error("Нет данных для оценки")
@@ -15,8 +20,12 @@ def evaluate(symbol: str = "BTC/USDT", timeframe: str = "1h", limit: int = 500):
 
     df = calculate_indicators(df)
 
+    strategies = STRATEGIES.copy()
+    if include_combos:
+        strategies.update(generate_all_indicator_strategies())
+
     results = []
-    for name, strategy in STRATEGIES.items():
+    for name, strategy in strategies.items():
         df_copy = strategy(df.copy())
         bt = Backtester(initial_balance=100000)
         bt.run_backtest(df_copy, signal_column="signal")
@@ -32,4 +41,14 @@ def evaluate(symbol: str = "BTC/USDT", timeframe: str = "1h", limit: int = 500):
 
 if __name__ == "__main__":
     logging.basicConfig(level=logging.INFO, format="%(message)s")
-    evaluate()
+    import argparse
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--all-combos",
+        action="store_true",
+        help="Evaluate every combination of indicators",
+    )
+    args = parser.parse_args()
+
+    evaluate(include_combos=args.all_combos)

--- a/utils/config.py
+++ b/utils/config.py
@@ -13,5 +13,5 @@ LEVERAGE = int(os.getenv("BYBIT_LEVERAGE", "5"))
 COMMISSION_RATE = float(os.getenv("COMMISSION_RATE", "0.001"))
 
 DEFAULT_RISK_PCT = 1.0    # риск 1% от баланса
-DEFAULT_SL_PCT   = 1.0    # стоп-лосс 2% от цены входа
+DEFAULT_SL_PCT   = 2.0    # стоп-лосс 2% от цены входа
 DEFAULT_TP_RATIO = 2.0    # тейк-профит в 2 раза дальше SL


### PR DESCRIPTION
## Summary
- create a generator for all indicator combos and append them to `STRATEGIES`
- allow evaluating all combinations via `strategy_evaluator`
- set default stop-loss to 2% so tests use expected position size

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68489dcd88e8832b865259bbff16fdc2