### PR TITLE
Adjust RSI thresholds

### DIFF
--- a/backtesting/backtesting.py
+++ b/backtesting/backtesting.py
@@ -1,5 +1,6 @@
 import logging
 from trading.risk_manager import calculate_position_size, calculate_sl_tp_levels
+from backtesting.strategies import RSI_BUY_THRESHOLD, RSI_SELL_THRESHOLD
 from utils.config import DEFAULT_RISK_PCT, DEFAULT_SL_PCT, DEFAULT_TP_RATIO
 
 # включаем вывод INFO-сообщений при запуске скрипта
@@ -118,7 +119,9 @@ if __name__ == "__main__":
 
     # 3) Формируем сигналы по RSI
     df["signal"] = df["RSI"].apply(
-        lambda rsi: "BUY" if rsi < 30 else ("SELL" if rsi > 70 else "HOLD")
+        lambda rsi: "BUY" if rsi < RSI_BUY_THRESHOLD else (
+            "SELL" if rsi > RSI_SELL_THRESHOLD else "HOLD"
+        )
     )
 
     # 4) Запускаем бэктест

--- a/backtesting/strategies.py
+++ b/backtesting/strategies.py
@@ -1,10 +1,16 @@
 import pandas as pd
 
+# Thresholds for RSI based signals.  Higher values make BUY/SELL entries
+# appear more often compared to the classic 30/70 levels.
+RSI_BUY_THRESHOLD = 40
+RSI_SELL_THRESHOLD = 60
 
 def rsi_strategy(df: pd.DataFrame) -> pd.DataFrame:
     """Generate BUY/SELL/HOLD signals based on RSI."""
     df["signal"] = df["RSI"].apply(
-        lambda rsi: "BUY" if rsi < 30 else ("SELL" if rsi > 70 else "HOLD")
+        lambda rsi: "BUY" if rsi < RSI_BUY_THRESHOLD else (
+            "SELL" if rsi > RSI_SELL_THRESHOLD else "HOLD"
+        )
     )
     return df
 
@@ -12,8 +18,14 @@ def rsi_strategy(df: pd.DataFrame) -> pd.DataFrame:
 def macd_rsi_strategy(df: pd.DataFrame) -> pd.DataFrame:
     """Combine MACD crossovers with RSI filters."""
     df["signal"] = "HOLD"
-    df.loc[(df["MACD"] > df["MACD_signal"]) & (df["RSI"] < 30), "signal"] = "BUY"
-    df.loc[(df["MACD"] < df["MACD_signal"]) & (df["RSI"] > 70), "signal"] = "SELL"
+    df.loc[
+        (df["MACD"] > df["MACD_signal"]) & (df["RSI"] < RSI_BUY_THRESHOLD),
+        "signal",
+    ] = "BUY"
+    df.loc[
+        (df["MACD"] < df["MACD_signal"]) & (df["RSI"] > RSI_SELL_THRESHOLD),
+        "signal",
+    ] = "SELL"
     return df
 
 
@@ -80,8 +92,8 @@ def macd_stochastic_strategy(df: pd.DataFrame) -> pd.DataFrame:
 def rsi_bollinger_strategy(df: pd.DataFrame) -> pd.DataFrame:
     """RSI oversold/overbought plus Bollinger band filter."""
     df["signal"] = "HOLD"
-    buy = (df["RSI"] < 30) & (df["close"] < df["BB_lower"])
-    sell = (df["RSI"] > 70) & (df["close"] > df["BB_upper"])
+    buy = (df["RSI"] < RSI_BUY_THRESHOLD) & (df["close"] < df["BB_lower"])
+    sell = (df["RSI"] > RSI_SELL_THRESHOLD) & (df["close"] > df["BB_upper"])
     df.loc[buy, "signal"] = "BUY"
     df.loc[sell, "signal"] = "SELL"
     return df
@@ -90,8 +102,8 @@ def rsi_bollinger_strategy(df: pd.DataFrame) -> pd.DataFrame:
 def rsi_stochastic_strategy(df: pd.DataFrame) -> pd.DataFrame:
     """RSI with Stochastic confirmation."""
     df["signal"] = "HOLD"
-    buy = (df["RSI"] < 30) & (df["STOCH_K"] > df["STOCH_D"])
-    sell = (df["RSI"] > 70) & (df["STOCH_K"] < df["STOCH_D"])
+    buy = (df["RSI"] < RSI_BUY_THRESHOLD) & (df["STOCH_K"] > df["STOCH_D"])
+    sell = (df["RSI"] > RSI_SELL_THRESHOLD) & (df["STOCH_K"] < df["STOCH_D"])
     df.loc[buy, "signal"] = "BUY"
     df.loc[sell, "signal"] = "SELL"
     return df
@@ -122,12 +134,12 @@ def rsi_macd_bollinger_strategy(df: pd.DataFrame) -> pd.DataFrame:
     df["signal"] = "HOLD"
     buy = (
         (df["MACD"] > df["MACD_signal"])
-        & (df["RSI"] < 30)
+        & (df["RSI"] < RSI_BUY_THRESHOLD)
         & (df["close"] < df["BB_lower"])
     )
     sell = (
         (df["MACD"] < df["MACD_signal"])
-        & (df["RSI"] > 70)
+        & (df["RSI"] > RSI_SELL_THRESHOLD)
         & (df["close"] > df["BB_upper"])
     )
     df.loc[buy, "signal"] = "BUY"
@@ -140,12 +152,12 @@ def rsi_macd_stochastic_strategy(df: pd.DataFrame) -> pd.DataFrame:
     df["signal"] = "HOLD"
     buy = (
         (df["MACD"] > df["MACD_signal"])
-        & (df["RSI"] < 30)
+        & (df["RSI"] < RSI_BUY_THRESHOLD)
         & (df["STOCH_K"] > df["STOCH_D"])
     )
     sell = (
         (df["MACD"] < df["MACD_signal"])
-        & (df["RSI"] > 70)
+        & (df["RSI"] > RSI_SELL_THRESHOLD)
         & (df["STOCH_K"] < df["STOCH_D"])
     )
     df.loc[buy, "signal"] = "BUY"
@@ -157,12 +169,12 @@ def rsi_bollinger_stochastic_strategy(df: pd.DataFrame) -> pd.DataFrame:
     """RSI with Bollinger band and Stochastic filters."""
     df["signal"] = "HOLD"
     buy = (
-        (df["RSI"] < 30)
+        (df["RSI"] < RSI_BUY_THRESHOLD)
         & (df["close"] < df["BB_lower"])
         & (df["STOCH_K"] > df["STOCH_D"])
     )
     sell = (
-        (df["RSI"] > 70)
+        (df["RSI"] > RSI_SELL_THRESHOLD)
         & (df["close"] > df["BB_upper"])
         & (df["STOCH_K"] < df["STOCH_D"])
     )
@@ -194,13 +206,13 @@ def rsi_macd_bollinger_stochastic_strategy(df: pd.DataFrame) -> pd.DataFrame:
     df["signal"] = "HOLD"
     buy = (
         (df["MACD"] > df["MACD_signal"])
-        & (df["RSI"] < 30)
+        & (df["RSI"] < RSI_BUY_THRESHOLD)
         & (df["close"] < df["BB_lower"])
         & (df["STOCH_K"] > df["STOCH_D"])
     )
     sell = (
         (df["MACD"] < df["MACD_signal"])
-        & (df["RSI"] > 70)
+        & (df["RSI"] > RSI_SELL_THRESHOLD)
         & (df["close"] > df["BB_upper"])
         & (df["STOCH_K"] < df["STOCH_D"])
     )
@@ -212,8 +224,8 @@ def rsi_macd_bollinger_stochastic_strategy(df: pd.DataFrame) -> pd.DataFrame:
 def rsi_ema_strategy(df: pd.DataFrame) -> pd.DataFrame:
     """Price above EMA with RSI filter."""
     df["signal"] = "HOLD"
-    buy = (df["close"] > df["EMA_20"]) & (df["RSI"] < 30)
-    sell = (df["close"] < df["EMA_20"]) & (df["RSI"] > 70)
+    buy = (df["close"] > df["EMA_20"]) & (df["RSI"] < RSI_BUY_THRESHOLD)
+    sell = (df["close"] < df["EMA_20"]) & (df["RSI"] > RSI_SELL_THRESHOLD)
     df.loc[buy, "signal"] = "BUY"
     df.loc[sell, "signal"] = "SELL"
     return df
@@ -278,8 +290,8 @@ def _create_combo_strategy(indicators: tuple[str, ...]):
 
         for ind in indicators:
             if ind == "RSI":
-                buy &= df["RSI"] < 30
-                sell &= df["RSI"] > 70
+                buy &= df["RSI"] < RSI_BUY_THRESHOLD
+                sell &= df["RSI"] > RSI_SELL_THRESHOLD
             elif ind == "MACD":
                 buy &= df["MACD"] > df["MACD_signal"]
                 sell &= df["MACD"] < df["MACD_signal"]

--- a/telegram_bot/bot.py
+++ b/telegram_bot/bot.py
@@ -49,8 +49,10 @@ async def status_command(update: Update, context: CallbackContext):
         df = calculate_indicators(df)
 
         # Генерируем простые сигналы по правилу (например, на основе RSI)
-        # Если RSI < 30, то сигнал BUY, если RSI > 70, то SELL, иначе HOLD
-        df["signal"] = df["RSI"].apply(lambda rsi: "BUY" if rsi < 30 else ("SELL" if rsi > 70 else "HOLD"))
+        # Если RSI < 40, то сигнал BUY, если RSI > 60, то SELL, иначе HOLD
+        df["signal"] = df["RSI"].apply(
+            lambda rsi: "BUY" if rsi < 40 else ("SELL" if rsi > 60 else "HOLD")
+        )
 
         # Создаем объект бэктестера и запускаем бэктест
         backtester = Backtester(initial_balance=10000, commission_rate=0.001)
@@ -559,9 +561,11 @@ async def backtest_command(update: Update, context: CallbackContext):
         # Здесь нам нужно сформировать сигналы для торговли.
         # Для простоты рассмотрим такой вариант: используем прогноз модели на каждую свечу.
         # Или можно применить простую стратегию, например:
-        # Если RSI < 30 -> BUY, если RSI > 70 -> SELL, иначе HOLD.
+        # Если RSI < 40 -> BUY, если RSI > 60 -> SELL, иначе HOLD.
         # В данном примере создадим столбец 'signal' с простыми правилами.
-        df["signal"] = df["RSI"].apply(lambda rsi: "BUY" if rsi < 30 else ("SELL" if rsi > 70 else "HOLD"))
+        df["signal"] = df["RSI"].apply(
+            lambda rsi: "BUY" if rsi < 40 else ("SELL" if rsi > 60 else "HOLD")
+        )
 
         # Создаем объект бэктестера
         backtester = Backtester(initial_balance=10000, commission_rate=0.001)
@@ -600,7 +604,9 @@ async def backtest_report(update: Update, context: CallbackContext):
     # 1) Получаем данные и сигналы
     df = get_candlestick_data("BTC/USDT", "1h", private=True)
     df = calculate_indicators(df)
-    df["signal"] = df["RSI"].apply(lambda rsi: "BUY" if rsi < 30 else ("SELL" if rsi > 70 else "HOLD"))
+    df["signal"] = df["RSI"].apply(
+        lambda rsi: "BUY" if rsi < 40 else ("SELL" if rsi > 60 else "HOLD")
+    )
 
     # 2) Прогоним бэктест
     backtester = Backtester(initial_balance=10000, commission_rate=0.001)


### PR DESCRIPTION
## Summary
- allow more trade entries by tuning the RSI thresholds to 40/60
- update demo/backtesting examples and Telegram bot accordingly

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6849f4c9243c832bb4d9d1cef49a933e