### PR TITLE
Add momentum indicators and strategy combinations

### DIFF
--- a/backtesting/strategies.py
+++ b/backtesting/strategies.py
@@ -277,6 +277,11 @@ COMBO_INDICATORS = [
     "EMA",
     "Bollinger",
     "Stochastic",
+    "MOM",
+    "ROC",
+    "CCI",
+    "OBV",
+    "WILLR",
 ]
 
 
@@ -310,6 +315,21 @@ def _create_combo_strategy(indicators: tuple[str, ...]):
             elif ind == "Stochastic":
                 buy &= df["STOCH_K"] > df["STOCH_D"]
                 sell &= df["STOCH_K"] < df["STOCH_D"]
+            elif ind == "MOM":
+                buy &= df["MOM"] > 0
+                sell &= df["MOM"] < 0
+            elif ind == "ROC":
+                buy &= df["ROC"] > 0
+                sell &= df["ROC"] < 0
+            elif ind == "CCI":
+                buy &= df["CCI"] > 0
+                sell &= df["CCI"] < 0
+            elif ind == "OBV":
+                buy &= df["OBV"] > df["OBV"].shift()
+                sell &= df["OBV"] < df["OBV"].shift()
+            elif ind == "WILLR":
+                buy &= df["WILLR"] < -80
+                sell &= df["WILLR"] > -20
 
         df.loc[buy, "signal"] = "BUY"
         df.loc[sell, "signal"] = "SELL"

--- a/indicators/indicators.py
+++ b/indicators/indicators.py
@@ -73,6 +73,43 @@ def calculate_stochastic(df, k_period=14, d_period=3):
     logger.info("Stochastic рассчитан.")
     return df
 
+def calculate_momentum(df, period=10):
+    """Adds Momentum indicator."""
+    df['MOM'] = df['close'] - df['close'].shift(period)
+    logger.info("Momentum рассчитан.")
+    return df
+
+def calculate_roc(df, period=12):
+    """Adds Rate of Change (ROC)."""
+    df['ROC'] = df['close'].pct_change(periods=period) * 100
+    logger.info("ROC рассчитан.")
+    return df
+
+def calculate_cci(df, period=20):
+    """Adds Commodity Channel Index (CCI)."""
+    tp = (df['high'] + df['low'] + df['close']) / 3
+    sma = tp.rolling(window=period).mean()
+    mad = tp.rolling(window=period).apply(lambda x: np.mean(np.abs(x - x.mean())), raw=True)
+    df['CCI'] = (tp - sma) / (0.015 * mad)
+    logger.info("CCI рассчитан.")
+    return df
+
+def calculate_obv(df):
+    """Adds On-Balance Volume (OBV)."""
+    obv = (np.sign(df['close'].diff()) * df['volume']).fillna(0).cumsum()
+    df['OBV'] = obv
+    logger.info("OBV рассчитан.")
+    return df
+
+def calculate_williams_r(df, period=14):
+    """Adds Williams %R (WILLR)."""
+    highest_high = df['high'].rolling(window=period).max()
+    lowest_low = df['low'].rolling(window=period).min()
+    denom = (highest_high - lowest_low).replace(0, np.nan)
+    df['WILLR'] = -100 * (highest_high - df['close']) / denom
+    logger.info("Williams %R рассчитан.")
+    return df
+
 def calculate_indicators(df):
     """
     Запускает расчёт всех индикаторов и удаляет строки с NaN.
@@ -84,6 +121,11 @@ def calculate_indicators(df):
     df = calculate_ema(df)
     df = calculate_bollinger_bands(df)
     df = calculate_stochastic(df)
+    df = calculate_momentum(df)
+    df = calculate_roc(df)
+    df = calculate_cci(df)
+    df = calculate_obv(df)
+    df = calculate_williams_r(df)
     df.dropna(inplace=True)
     logger.info("Все индикаторы рассчитаны и начальные NaN значения удалены.")
     return df

--- a/tests/test_indicators.py
+++ b/tests/test_indicators.py
@@ -8,13 +8,15 @@ def test_calculate_indicators_adds_columns():
         'open':  np.arange(1, 31),
         'high':  np.arange(2, 32),
         'low':   np.arange(0, 30),
-        'close': np.arange(1, 31)
+        'close': np.arange(1, 31),
+        'volume': np.ones(30)
     }
     df = pd.DataFrame(data)
     result = calculate_indicators(df)
     expected_cols = [
         'RSI', 'MACD', 'MACD_signal', 'ATR', 'SMA_20', 'EMA_20',
-        'BB_upper', 'BB_middle', 'BB_lower', 'STOCH_K', 'STOCH_D'
+        'BB_upper', 'BB_middle', 'BB_lower', 'STOCH_K', 'STOCH_D',
+        'MOM', 'ROC', 'CCI', 'OBV', 'WILLR'
     ]
     for col in expected_cols:
         assert col in result.columns


### PR DESCRIPTION
## Summary
- extend indicator suite with Momentum, ROC, CCI, OBV and Williams %R
- generate strategy combinations including the new indicators
- ensure indicator calculation uses volume column
- update indicator tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6849fa99e388832b81d1251f667bc03d