### PR TITLE
Add trade count to strategy evaluator output

### DIFF
--- a/backtesting/strategy_evaluator.py
+++ b/backtesting/strategy_evaluator.py
@@ -29,12 +29,12 @@ def evaluate(
         df_copy = strategy(df.copy())
         bt = Backtester(initial_balance=100000)
         bt.run_backtest(df_copy, signal_column="signal")
-        results.append((name, bt.balance))
+        results.append((name, bt.balance, len(bt.trades)))
 
     results.sort(key=lambda x: x[1], reverse=True)
     print("=== Strategy results ===")
-    for name, bal in results:
-        print(f"{name:12s} -> final balance: {bal:.2f}")
+    for name, bal, trades in results:
+        print(f"{name:12s} -> final balance: {bal:.2f}, trades: {trades}")
     if results:
         print(f"Best strategy: {results[0][0]}")
 


### PR DESCRIPTION
## Summary
- show trade counts for each strategy in `strategy_evaluator`

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684a044f6e80832bbb3509a6d56cd5e7