### PR TITLE
Add BTC history fetcher

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,11 @@ This project contains a cryptocurrency trading bot with a Telegram interface. It
    ```bash
    pytest
    ```
-5. Start the Telegram bot:
+5. (Optional) download two years of historical BTC data for backtesting:
+   ```bash
+   python scripts/fetch_btc_history.py
+   ```
+6. Start the Telegram bot:
    ```bash
    python telegram_bot/bot.py
    ```

--- a/backtesting/backtesting.py
+++ b/backtesting/backtesting.py
@@ -1,4 +1,5 @@
 import logging
+import os
 from trading.risk_manager import calculate_position_size, calculate_sl_tp_levels
 from backtesting.strategies import RSI_BUY_THRESHOLD, RSI_SELL_THRESHOLD
 from utils.config import DEFAULT_RISK_PCT, DEFAULT_SL_PCT, DEFAULT_TP_RATIO
@@ -103,13 +104,17 @@ class Backtester:
 
 if __name__ == "__main__":
     logging.basicConfig(level=logging.INFO, format="%(message)s")
-    from data.data_manager import get_candlestick_data
+    from data.data_manager import get_candlestick_data, load_ohlcv_from_csv
     from indicators.indicators import calculate_indicators
     from collections import Counter
     import matplotlib.pyplot as plt
 
     # 1) Загружаем данные
-    df = get_candlestick_data(symbol="BTC/USDT", timeframe="1h", private=True)
+    csv_path = "data/btc_usdt_1h_2y.csv"
+    if os.path.exists(csv_path):
+        df = load_ohlcv_from_csv(csv_path)
+    else:
+        df = get_candlestick_data(symbol="BTC/USDT", timeframe="1h", private=True)
     if df.empty:
         print("Не удалось получить данные для бэктеста")
         exit(1)

--- a/data/data_manager.py
+++ b/data/data_manager.py
@@ -2,7 +2,7 @@
 import ccxt
 import pandas as pd
 import sqlite3
-from datetime import datetime
+from datetime import datetime, timedelta
 import os
 import logging
 from dotenv import load_dotenv
@@ -72,3 +72,32 @@ def save_to_db(df, symbol, timeframe, db_path="market_data.db"):
     df.to_sql("ohlcv", conn, if_exists="append", index=False)
     conn.close()
     logger.info(f"Сохранено {len(df)} записей для {symbol} в базу данных {db_path}.")
+
+
+def fetch_last_two_years_to_csv(
+    symbol: str = "BTC/USDT",
+    timeframe: str = "1h",
+    csv_path: str = "data/btc_usdt_1h_2y.csv",
+    private: bool = False,
+):
+    """Скачать последние 2 года данных и сохранить их в CSV."""
+    end_time = datetime.utcnow()
+    start_time = end_time - timedelta(days=730)
+    since_ms = int(start_time.timestamp() * 1000)
+    df = get_candlestick_data(symbol, timeframe, since=since_ms, private=private)
+    if not df.empty:
+        os.makedirs(os.path.dirname(csv_path), exist_ok=True)
+        df.to_csv(csv_path, index=False)
+        logger.info(f"Исторические данные сохранены в {csv_path}")
+    return df
+
+
+def load_ohlcv_from_csv(csv_path: str) -> pd.DataFrame:
+    """Загрузить OHLCV данные из CSV-файла."""
+    if not os.path.exists(csv_path):
+        logger.error(f"Файл {csv_path} не найден")
+        return pd.DataFrame()
+    df = pd.read_csv(csv_path)
+    if "start_at" in df.columns:
+        df["start_at"] = pd.to_datetime(df["start_at"])
+    return df

--- a/scripts/fetch_btc_history.py
+++ b/scripts/fetch_btc_history.py
@@ -1,0 +1,8 @@
+import logging
+from data.data_manager import fetch_last_two_years_to_csv
+
+
+logging.basicConfig(level=logging.INFO, format="%(message)s")
+
+if __name__ == "__main__":
+    fetch_last_two_years_to_csv(symbol="BTC/USDT", timeframe="1h", private=True)


### PR DESCRIPTION
## Summary
- add helper to download two years of hourly BTC data
- load from CSV in backtester if available
- expose a simple fetching script
- document how to fetch historical data

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684a099f0d14832b90c5abdd0058c2ee